### PR TITLE
Fixes to versions of packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # vehicledata
 This project performs some very basic exploratory analysis on a set of vehicle listings circa 2019. The main purpose is to demo web development, which was implemented via Python using Streamlit, and hosted by Render. Data was handled and visualized using the Pandas library and Plotly Express, respectively.
 
+Use this URL to see the results of this repo:
+
+https://vehicledata-ffeh.onrender.com/
+
 # If you want to launch locally
 
 - Ensure Python 3.11 is installed (this project was made with 3.11, but later versions should also work), along with `pip` 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ scipy==1.11.1
 streamlit==1.25.0
 altair==5.0.1
 plotly==5.15.0
+pyarrow==17.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-pandas==2.0.3
-scipy==1.11.1
-streamlit==1.25.0
-altair==5.0.1
-plotly==5.15.0
+altair==5.4.1
+pandas==2.2.2
+plotly==5.24.0
 pyarrow==17.0.0
+scipy==1.14.1
+streamlit==1.38.0


### PR DESCRIPTION
The requirements.txt file lists several Python library versions which Render can use. The particular combination of versions listed in the project instructions results in the deployed version throwing an ArrowTypeError. This PR fixes that by updating those versions to match the ones in my local's venv.